### PR TITLE
pcrbatch bug corrected

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 LazyLoad: yes
 LazyData: yes
 Title: Modelling and Analysis of Real-Time PCR Data
-Version: 1.4-1
-Date: 2018-05-29
+Version: 1.4-2
+Date: 2024-08-09
 Author: Andrej-Nikolai Spiess <a.spiess@uke.uni-hamburg.de>        
 Maintainer: Andrej-Nikolai Spiess <a.spiess@uke.uni-hamburg.de>
 Description: Model fitting, optimal model selection and calculation of various features that are essential in the analysis of quantitative real-time polymerase chain reaction (qPCR).

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+qpcR 1.4 - 2 (09-08-2024)
+Changes and bug-fixes in functions:
+  Corrected pcrbatch 'if' with condition length>1. 
+  CHANGES IN R 4.2.0:
+  SIGNIFICANT USER-VISIBLE CHANGES:
+    * Calling if() or while() with a condition of length greater than
+      one gives an error rather than a warning.  Consequently,
+      environment variable _R_CHECK_LENGTH_1_CONDITION_ no longer has
+      any effect.
 qpcR 1.4 - 1 (29-05-2018)
 Changes and bug-fixes in functions:
   * removed a bug in 'plot.pcrfit' that would display an additional line in the graph when setting type = "l".

--- a/R/pcrbatch.r
+++ b/R/pcrbatch.r
@@ -30,7 +30,7 @@ verbose = TRUE,
   if (!is.numeric(baseline)) baseline <- match.arg(baseline)  
       
   ## make initial 'modlist'
-  if (class(x) != "modlist") {  
+  if (class(x)[1] != "modlist") {  
     if (names(x)[cyc] != "Cycles") stop("Column 1 should be named 'Cycles'!")
     modLIST <- try(modlist(x = x, cyc = cyc, fluo = fluo, model = model, check = check, checkPAR = checkPAR,
                            remove = remove, exclude = exclude, labels = labels, norm = norm, baseline = baseline,


### PR DESCRIPTION
Corrected pcrbatch 'if' with condition length>1. 
caused by
 CHANGES IN R 4.2.0:
  SIGNIFICANT USER-VISIBLE CHANGES:
    * Calling if() or while() with a condition of length greater than
      one gives an error rather than a warning.  Consequently,
      environment variable _R_CHECK_LENGTH_1_CONDITION_ no longer has
      any effect.